### PR TITLE
MO: id_module not set, so checkboxes does not disable next submit input

### DIFF
--- a/views/templates/hook/displayGDPRConsent.tpl
+++ b/views/templates/hook/displayGDPRConsent.tpl
@@ -23,10 +23,10 @@
 *  International Registered Trademark & Property of PrestaShop SA
 *}
 
-<div id="gdpr_consent" class="gdpr_module_{$id_module|escape:'htmlall':'UTF-8'}">
+<div id="gdpr_consent" class="gdpr_module_{$psgdpr_id_module|escape:'htmlall':'UTF-8'}">
     <span class="custom-checkbox">
         {*<div>*}
-            <input id="psgdpr_consent_checkbox_{$id_module|escape:'htmlall':'UTF-8'}" name="psgdpr_consent_checkbox" type="checkbox" value="1">
+            <input id="psgdpr_consent_checkbox_{$psgdpr_id_module|escape:'htmlall':'UTF-8'}" name="psgdpr_consent_checkbox" type="checkbox" value="1">
             <span><i class="material-icons rtl-no-flip checkbox-checked psgdpr_consent_icon"></i></span>
         {*</div>*}
         <label class="psgdpr_consent_message">


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | MO: id_module not set, so checkboxes does not disable next submit input 
| Type?         | bug fix
| Category?     | MO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | -
| How to test?  | Enable the module and the display of the checkbx inside native contactform module, whithout this correction, the input submit is not disabled as it should when the people does not consent to GDRP
