### PR TITLE
Remove usage of $link in customerAccount.tpl

### DIFF
--- a/views/templates/front/customerAccount.tpl
+++ b/views/templates/front/customerAccount.tpl
@@ -13,7 +13,7 @@
 * International Registered Trademark & Property of PrestaShop SA
 *}
 
-<a class="col-lg-4 col-md-6 col-sm-6 col-xs-12" id="identity-link" href="{$link->getModuleLink('psgdpr', 'gdpr')}">
+<a class="col-lg-4 col-md-6 col-sm-6 col-xs-12" id="identity-link" href="{$front_controller}">
     <span class="link-item">
         <i class="material-icons">account_box</i> {l s='My personal data' mod='psgdpr'}
     </span>


### PR DESCRIPTION
Hi,

In the function hookDisplayCustomerAccount the link to the controller is defined with the variable **front_controller**.
But this var is not used in the file customerAccount.tpl
To be consistent with the code, we should replace the use of $link by this variable.

Regards,