### PR TITLE
Fix long2ip() parameter type

### DIFF
--- a/psgdpr.php
+++ b/psgdpr.php
@@ -785,7 +785,7 @@ class Psgdpr extends Module
                 array_push($messages, array(
                     'id_customer_thread' => $message['id_customer_thread'],
                     'message' => $message['message'],
-                    'ip' => long2ip((int)$message['ip_address']),
+                    'ip' => (int)$message['ip_address'] == $message['ip_address'] ? long2ip((int)$message['ip_address']) : $message['ip_address'],
                     'date_add' => $message['date_add'],
                 ));
             }

--- a/psgdpr.php
+++ b/psgdpr.php
@@ -785,7 +785,7 @@ class Psgdpr extends Module
                 array_push($messages, array(
                     'id_customer_thread' => $message['id_customer_thread'],
                     'message' => $message['message'],
-                    'ip' => long2ip((int)$message['ip_address']),
+                    'ip' => (int) $message['ip_address'] == $message['ip_address'] ? long2ip((int) $message['ip_address']) : $message['ip_address'],
                     'date_add' => $message['date_add'],
                 ));
             }

--- a/psgdpr.php
+++ b/psgdpr.php
@@ -785,7 +785,7 @@ class Psgdpr extends Module
                 array_push($messages, array(
                     'id_customer_thread' => $message['id_customer_thread'],
                     'message' => $message['message'],
-                    'ip' => long2ip($message['ip_address']),
+                    'ip' => long2ip((int)$message['ip_address']),
                     'date_add' => $message['date_add'],
                 ));
             }

--- a/psgdpr.php
+++ b/psgdpr.php
@@ -785,7 +785,7 @@ class Psgdpr extends Module
                 array_push($messages, array(
                     'id_customer_thread' => $message['id_customer_thread'],
                     'message' => $message['message'],
-                    'ip' => (int)$message['ip_address'] == $message['ip_address'] ? long2ip((int)$message['ip_address']) : $message['ip_address'],
+                    'ip' => long2ip((int)$message['ip_address']),
                     'date_add' => $message['date_add'],
                 ));
             }


### PR DESCRIPTION
Fix https://github.com/PrestaShop/psgdpr/issues/61
long2ip() expects parameter 1 to be integer, string given