### PR TITLE
Fix Trying to get property of non-object

### DIFF
--- a/psgdpr.php
+++ b/psgdpr.php
@@ -536,9 +536,9 @@ class Psgdpr extends Module
 
         $module_list = array();
         foreach ($modules as $module) {
-            $Module = Module::getInstanceById($module['id_module']);
+            $moduleInstance = Module::getInstanceById($module['id_module']);
             
-            if ($Module == false) {
+            if ($moduleInstance == false) {
                 continue;
             }
 
@@ -546,8 +546,8 @@ class Psgdpr extends Module
             foreach ($languages as $lang) {
                 $module['message'][$lang['id_lang']] = GDPRConsent::getConsentMessage($module['id_module'], $lang['id_lang']);
             }
-            $module['displayName'] = $Module->displayName;
-            $module['logoPath'] = Tools::getHttpHost(true).$physical_uri.'modules/'.$Module->name.'/logo.png';
+            $module['displayName'] = $moduleInstance->displayName;
+            $module['logoPath'] = Tools::getHttpHost(true).$physical_uri.'modules/'.$moduleInstance->name.'/logo.png';
 
             array_push($module_list, $module);
         }

--- a/psgdpr.php
+++ b/psgdpr.php
@@ -537,6 +537,10 @@ class Psgdpr extends Module
         $module_list = array();
         foreach ($modules as $module) {
             $Module = Module::getInstanceById($module['id_module']);
+            
+            if ($Module == false) {
+                continue;
+            }
 
             $module['active'] = GDPRConsent::getConsentActive($module['id_module']);
             foreach ($languages as $lang) {

--- a/psgdpr.php
+++ b/psgdpr.php
@@ -492,7 +492,7 @@ class Psgdpr extends Module
                 break;
         }
 
-        if ($active == false) {
+        if ($active === false) {
             return;
         }
 
@@ -537,7 +537,7 @@ class Psgdpr extends Module
         $module_list = array();
         foreach ($modules as $module) {
             $moduleInstance = Module::getInstanceById($module['id_module']);
-            
+
             if ($moduleInstance == false) {
                 continue;
             }

--- a/psgdpr.php
+++ b/psgdpr.php
@@ -492,7 +492,7 @@ class Psgdpr extends Module
                 break;
         }
 
-        if ($active === false) {
+        if ($active == false) {
             return;
         }
 

--- a/psgdpr.php
+++ b/psgdpr.php
@@ -538,7 +538,7 @@ class Psgdpr extends Module
         foreach ($modules as $module) {
             $moduleInstance = Module::getInstanceById($module['id_module']);
 
-            if ($moduleInstance == false) {
+            if ($moduleInstance === false) {
                 continue;
             }
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | `Trying to get property of non-object` error if a module is not found
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | https://github.com/PrestaShop/psgdpr/issues/47
| How to test?  | Steps to reproduce the behavior bellow
- Install Official GDPR compliance v1.1.2
- Install Mail alerts for example
- Configure a message in GDPR, section Configure your checkboxes
- Save and exit
- Uninstall module installed in step 2.
- Go to GDPR and you'll see the notice and also the message box after the uninstalled module as per screenshot below.