### PR TITLE
Order confirmation form

### DIFF
--- a/psgdpr.php
+++ b/psgdpr.php
@@ -484,6 +484,7 @@ class Psgdpr extends Module
                 break;
             case 'authentication':
             case 'order':
+            case 'order-confirmation':
                 $active = Configuration::get('PSGDPR_CREATION_FORM_SWITCH');
                 $label = Configuration::get('PSGDPR_CREATION_FORM', $id_lang);
                 break;


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Include GDPR checkbox also on the order confirmation page
| Type?         | improvement
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | The change affects only the default Order Confirmation page. By default, Prestashop displays a form allowing guests to register an account after placing an order, but that form lacks the DGPR checkbox. My change only makes that checkbox appear in that form.