### PR TITLE
Prevent deleting data when non-existing customer

### DIFF
--- a/psgdpr.php
+++ b/psgdpr.php
@@ -832,8 +832,10 @@ class Psgdpr extends Module
         switch ($delete) {
             case 'customer':
                 $customer = new Customer((int)$value);
-                $this->deleteDataFromModules($customer);
-                $this->deleteDataFromPrestashop($customer);
+                if (Validate::isLoadedObject($customer)) {
+                    $this->deleteDataFromModules($customer);
+                    $this->deleteDataFromPrestashop($customer);
+                }
                 break;
             case 'email':
                 $data = array('email' => $value);
@@ -848,8 +850,17 @@ class Psgdpr extends Module
         }
     }
 
+    /**
+     * @param Customer $customer
+     *
+     * @return bool
+     */
     public function deleteDataFromPrestashop($customer)
     {
+        if (!Validate::isLoadedObject($customer)) {
+            return false;
+        }
+
         $queries = array();
 
         // assign order to an anonymous account in order to keep stats -> let customer->delete() do the job
@@ -890,7 +901,8 @@ class Psgdpr extends Module
         }
 
         GDPRLog::addLog((int)$customer->id, 'delete', 0, 0);
-        $customer->delete(); // delete the customer
+
+        return $customer->delete(); // delete the customer
     }
 
     public function deleteDataFromModules($customer)


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Prevent deleting data when non-existing customer
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | https://github.com/PrestaShop/psgdpr/issues/77
| How to test?  | For example `ps-admin/index.php?controller=AdminAjaxPsgdpr&token=0fdd3c1562cd6e510b7f8f1bc9b35d56&ajax=true&action=DeleteCustomer&delete=customer&value=0` (Do not forget to change token by yours in this example)

Prevent deleting data when non-existing customer, eg. $customer->id = 0
* All specific price not associated to a customer will be deleted
* All cart rules not associated to a customer will be deleted
* All anonymous customer thread and messages will be deleted

Bug reported from Addons