### PR TITLE
Remove ModuleAdminControllers from SEO & URLs page

### DIFF
--- a/upgrade/upgrade-1.1.4.php
+++ b/upgrade/upgrade-1.1.4.php
@@ -38,23 +38,12 @@ function upgrade_module_1_1_4($module)
     $result = true;
 
     // Remove our ModuleAdminControllers from SEO & URLs page
-    foreach ($module->adminControllers as $controller) {
-        $metaId = Db::getInstance()->getValue('
-            SELECT id_meta
-            FROM `' . _DB_PREFIX_ . 'meta`
-            WHERE page="' . pSQL('module-' . $module->name . '-' . $controller) . '"'
-        );
+    $metaCollection = new PrestaShopCollection('Meta');
+    $metaCollection->where('page', 'like', 'module-' . $module->name . '-Admin%');
 
-        if ($metaId) {
-            $result = $result && Db::getInstance()->delete(
-                'meta_lang',
-                'id_meta = ' . (int) $metaId
-            );
-            $result = $result && Db::getInstance()->delete(
-                'meta',
-                'id_meta = ' . (int) $metaId
-            );
-        }
+    foreach ($metaCollection->getAll() as $meta) {
+        /** @var Meta $meta */
+        $result = $result && (bool) $meta->delete();
     }
 
     return $result;

--- a/upgrade/upgrade-1.1.4.php
+++ b/upgrade/upgrade-1.1.4.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * 2007-2016 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2016 PrestaShop SA
+ * @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+/**
+ * @param Psgdpr $module
+ *
+ * @return bool
+ */
+function upgrade_module_1_1_4($module)
+{
+    $result = true;
+
+    // Remove our ModuleAdminControllers from SEO & URLs page
+    foreach ($module->adminControllers as $controller) {
+        $metaId = Db::getInstance()->getValue('
+            SELECT id_meta
+            FROM `' . _DB_PREFIX_ . 'meta`
+            WHERE page="' . pSQL('module-' . $module->name . '-' . $controller) . '"'
+        );
+
+        if ($metaId) {
+            $result = $result && Db::getInstance()->delete(
+                'meta_lang',
+                'id_meta = ' . (int) $metaId
+            );
+            $result = $result && Db::getInstance()->delete(
+                'meta',
+                'id_meta = ' . (int) $metaId
+            );
+        }
+    }
+
+    return $result;
+}


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | `Module::$controllers` is an undocumented reserved var used to register `ModuleFrontController` in SEO & URLs page on BO in order to allow merchant to customize rewrite link and page title, meta keyword, meta description... It should never be used for a `ModuleAdminController`
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | See bellow

Install current module : 
Go to BO > Preferences > SEO & URLs, search `psgdpr` and see it in the list: this list item is bad.

With new module :
- if you upgrade, the bad list item is gone
- if you install, it will not add the bad list item

![psgdpr-admincontrollers](https://user-images.githubusercontent.com/5262628/78536561-58906000-77ee-11ea-874a-3cb0a7b8d79c.png)
![psgdpr-admincontroller](https://user-images.githubusercontent.com/5262628/78536569-5b8b5080-77ee-11ea-95e4-b334a2d665d1.png)
