### PR TITLE
Fixed some translations for the German language

### DIFF
--- a/translations/de.php
+++ b/translations/de.php
@@ -1,11 +1,12 @@
 <?php
 /**
- * 2007-2020 PrestaShop and Contributors
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
  *
  * NOTICE OF LICENSE
  *
  * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
- * that is bundled with this package in the file LICENSE.txt.
+ * that is bundled with this package in the file LICENSE.md.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/AFL-3.0
  * If you did not receive a copy of the license and are unable to
@@ -13,9 +14,8 @@
  * to license@prestashop.com so we can send you a copy immediately.
  *
  * @author    PrestaShop SA <contact@prestashop.com>
- * @copyright 2007-2020 PrestaShop SA and Contributors
+ * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
- * International Registered Trademark & Property of PrestaShop SA
  */
 global $_MODULE;
 $_MODULE = [];
@@ -38,19 +38,19 @@ $_MODULE['<{psgdpr}prestashop>customerpersonaldata17_01cb324ae91e9bd16213cc29453
 $_MODULE['<{psgdpr}prestashop>customerpersonaldata17_af5efea250326c1c34d69aa9364b482c'] = 'Kontaktseite.';
 $_MODULE['<{psgdpr}prestashop>customerpersonaldata17_332087a4991d8bc866abd3fd78a2e514'] = 'Wir werden Ihre Anfrage überprüfen und so schnell wie möglich auf Sie zurückkommen.';
 $_MODULE['<{psgdpr}prestashop>customeraccount_5868129c4526891dddb05b8e59c33572'] = 'Meine persönlichen Daten';
-$_MODULE['<{psgdpr}prestashop>customerpersonaldata16_d95cf4ab2cbf1dfb63f066b50558b07d'] = 'Mein Konto';
-$_MODULE['<{psgdpr}prestashop>customerpersonaldata16_c654dacdea4ad6f75ad36553a8a947cd'] = 'Meine persönlichen Daten';
-$_MODULE['<{psgdpr}prestashop>customerpersonaldata16_c654dacdea4ad6f75ad36553a8a947cd'] = 'Meine persönlichen Daten';
-$_MODULE['<{psgdpr}prestashop>customerpersonaldata16_a8308387f3ffc2d045d2b6125e74317d'] = 'Zugang zu meinen Daten';
-$_MODULE['<{psgdpr}prestashop>customerpersonaldata16_915f4446a47b51378e37374cfbb72d7f'] = 'Sie haben jederzeit das Recht, die unserer Seite zur Verfügung gestellten Daten abzurufen. Klicken Sie auf „Meine Daten abrufen“, um eine Kopie Ihrer persönlichen Daten automatisch als PDF- oder CSV-Datei herunter.';
-$_MODULE['<{psgdpr}prestashop>customerpersonaldata16_49b5d04f5f20820830f080d4674c8669'] = 'MEINE CSV-DATEN ABRUFEN';
-$_MODULE['<{psgdpr}prestashop>customerpersonaldata16_7b0b06bfe69473081553bcccb12ca068'] = 'MEINE PDF-DATEN ABRUFEN';
-$_MODULE['<{psgdpr}prestashop>customerpersonaldata16_91a49c1d45a5d37e85658d01b6f37423'] = 'Berichtigungs- & Löschanfragen';
-$_MODULE['<{psgdpr}prestashop>customerpersonaldata16_01cb324ae91e9bd16213cc2945334249'] = 'Sie haben das Recht, alle persönlichen Informationen auf der Seite „Mein Konto“ zu ändern. Bitte kontaktieren Sie uns für jede andere Anfrage bezüglich der Berichtigung und/oder Löschung Ihrer persönlichen Daten über unsere';
-$_MODULE['<{psgdpr}prestashop>customerpersonaldata16_af5efea250326c1c34d69aa9364b482c'] = 'Kontaktseite.';
-$_MODULE['<{psgdpr}prestashop>customerpersonaldata16_332087a4991d8bc866abd3fd78a2e514'] = 'Wir werden Ihre Anfrage überprüfen und so schnell wie möglich auf Sie zurückkommen.';
-$_MODULE['<{psgdpr}prestashop>customerpersonaldata16_0b3db27bc15f682e92ff250ebb167d4b'] = 'Zurück zu Ihrem Konto';
-$_MODULE['<{psgdpr}prestashop>customerpersonaldata16_8cf04a9734132302f96da8e113e80ce5'] = 'Startseite';
+$_MODULE['<{psgdpr}prestashop>customerpersonaldata_d95cf4ab2cbf1dfb63f066b50558b07d'] = 'Mein Konto';
+$_MODULE['<{psgdpr}prestashop>customerpersonaldata_c654dacdea4ad6f75ad36553a8a947cd'] = 'Meine persönlichen Daten';
+$_MODULE['<{psgdpr}prestashop>customerpersonaldata_c654dacdea4ad6f75ad36553a8a947cd'] = 'Meine persönlichen Daten';
+$_MODULE['<{psgdpr}prestashop>customerpersonaldata_a8308387f3ffc2d045d2b6125e74317d'] = 'Zugang zu meinen Daten';
+$_MODULE['<{psgdpr}prestashop>customerpersonaldata_915f4446a47b51378e37374cfbb72d7f'] = 'Sie haben jederzeit das Recht, die unserer Seite zur Verfügung gestellten Daten abzurufen. Klicken Sie auf „Meine Daten abrufen“, um eine Kopie Ihrer persönlichen Daten automatisch als PDF- oder CSV-Datei herunter.';
+$_MODULE['<{psgdpr}prestashop>customerpersonaldata_49b5d04f5f20820830f080d4674c8669'] = 'MEINE CSV-DATEN ABRUFEN';
+$_MODULE['<{psgdpr}prestashop>customerpersonaldata_7b0b06bfe69473081553bcccb12ca068'] = 'MEINE PDF-DATEN ABRUFEN';
+$_MODULE['<{psgdpr}prestashop>customerpersonaldata_91a49c1d45a5d37e85658d01b6f37423'] = 'Berichtigungs- & Löschanfragen';
+$_MODULE['<{psgdpr}prestashop>customerpersonaldata_01cb324ae91e9bd16213cc2945334249'] = 'Sie haben das Recht, alle persönlichen Informationen auf der Seite „Mein Konto“ zu ändern. Bitte kontaktieren Sie uns für jede andere Anfrage bezüglich der Berichtigung und/oder Löschung Ihrer persönlichen Daten über unsere';
+$_MODULE['<{psgdpr}prestashop>customerpersonaldata_af5efea250326c1c34d69aa9364b482c'] = 'Kontaktseite.';
+$_MODULE['<{psgdpr}prestashop>customerpersonaldata_332087a4991d8bc866abd3fd78a2e514'] = 'Wir werden Ihre Anfrage überprüfen und so schnell wie möglich auf Sie zurückkommen.';
+$_MODULE['<{psgdpr}prestashop>customerpersonaldata_0b3db27bc15f682e92ff250ebb167d4b'] = 'Zurück zu Ihrem Konto';
+$_MODULE['<{psgdpr}prestashop>customerpersonaldata_8cf04a9734132302f96da8e113e80ce5'] = 'Startseite';
 $_MODULE['<{psgdpr}prestashop>personaldata.connections-tab_93bd48ecb9c4d5c4eec7fefffbb2070f'] = 'Letzte Verbindungen';
 $_MODULE['<{psgdpr}prestashop>personaldata.connections-tab_33e29c1d042c0923008f78b46af94984'] = 'Ursprüngliche Anfrage';
 $_MODULE['<{psgdpr}prestashop>personaldata.connections-tab_57f32d7d0e6672cc2b60bc7a49f91453'] = 'Aufgerufene Seite';


### PR DESCRIPTION
Some lines of translation have an incorrect template name.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Some lines of translation have an incorrect template name. Any of Prestashop 1.7 versions. 
| Type?         | bug fix 
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | no
| How to test?  | You should install the module in the shop on german language, and you can see the gdpr block in the customer account is not translating

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
