### PR TITLE
Modify GitHub Action PHP CS Fixer to not depend on prestashopcorp

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -17,10 +17,25 @@ jobs:
     name: PHP-CS-Fixer
     runs-on: ubuntu-latest
     steps:
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+              php-version: '7.4'
+
       - name: Checkout
         uses: actions/checkout@v2.0.0
+
+      - name: Cache dependencies
+        uses: actions/cache@v2
+        with:
+          path: vendor
+          key: php-${{ hashFiles('composer.lock') }}
+
+      - name: Install dependencies
+        run: composer install
+
       - name: Run PHP-CS-Fixer
-        uses: prestashopcorp/github-action-php-cs-fixer@master
+        run: ./vendor/bin/php-cs-fixer fix --dry-run --diff --using-cache=no --diff-format udiff
   phpstan:
     name: PHPStan
     runs-on: ubuntu-latest

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-              php-version: '7.4'
+          php-version: '7.4'
 
       - name: Checkout
         uses: actions/checkout@v2.0.0


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Modify GitHub Action PHP CS Fixer to not depend on prestashopcorp.
| Type?         | improvement
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
