### PR TITLE
Fix getAdminLink 3rd argument

### DIFF
--- a/psgdpr.php
+++ b/psgdpr.php
@@ -341,7 +341,7 @@ class Psgdpr extends Module
      */
     public function getContent()
     {
-        $moduleAdminLink = $this->context->link->getAdminLink('AdminModules', true, false, ['configure' => $this->name]);
+        $moduleAdminLink = $this->context->link->getAdminLink('AdminModules', true, [], ['configure' => $this->name]);
 
         $id_lang = $this->context->language->id;
         $id_shop = $this->context->shop->id;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | The method `Link::getAdminLink()` expect an array as 3rd argument, `false` was given. This PR aims to fix that.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | CI should be green

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
