### PR TITLE
Avoid warning open_basedir restriction

### DIFF
--- a/psgdpr.php
+++ b/psgdpr.php
@@ -625,7 +625,7 @@ class Psgdpr extends Module
             'ps_version' => $this->ps_version,
         ]);
 
-        return $this->display(dirname(__FILE__), '/views/templates/front/customerAccount.tpl');
+        return $this->fetch('module:' . $this->name . '/views/templates/front/customerAccount.tpl');
     }
 
     /**

--- a/psgdpr.php
+++ b/psgdpr.php
@@ -625,7 +625,7 @@ class Psgdpr extends Module
             'ps_version' => $this->ps_version,
         ]);
 
-        return $this->fetch('module:' . $this->name . '/views/templates/front/customerAccount.tpl');
+        return $this->display(dirname(__FILE__), 'views/templates/front/customerAccount.tpl');
     }
 
     /**


### PR DESCRIPTION

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  |  Avoided the "Warning: file_exists(): open_basedir restriction in effect. File(/views/templates/front/customerAccount.tpl) is not within the allowed path(s)" due a slash before the "views" on the file route. Also update the line with the "$this->fetch" function
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? |  no
| Fixed ticket? | 
| How to test?  | Enable debug mode, check that warning not rise

