### PR TITLE
Add index on psgdpr_log

### DIFF
--- a/psgdpr.php
+++ b/psgdpr.php
@@ -119,7 +119,7 @@ class Psgdpr extends Module
         // Settings
         $this->name = 'psgdpr';
         $this->tab = 'administration';
-        $this->version = '1.3.0';
+        $this->version = '1.4.0';
         $this->author = 'PrestaShop';
         $this->need_instance = 0;
 

--- a/sql/install.php
+++ b/sql/install.php
@@ -51,6 +51,11 @@ $sql[] = ' CREATE TABLE IF NOT EXISTS `' . _DB_PREFIX_ . 'psgdpr_log` (
         INDEX (`id_customer`)
         ) ENGINE=' . _MYSQL_ENGINE_ . ' DEFAULT CHARSET=UTF8;';
 
+
+
+$sql[] = ' ALTER TABLE `' . _DB_PREFIX_ . 'psgdpr_log` 
+        ADD INDEX( `id_customer`, `id_guest`, `client_name`, `id_module`, `date_add`, `date_upd`); '
+
 foreach ($sql as $query) {
     if (Db::getInstance()->execute($query) == false) {
         return false;

--- a/sql/install.php
+++ b/sql/install.php
@@ -51,10 +51,8 @@ $sql[] = ' CREATE TABLE IF NOT EXISTS `' . _DB_PREFIX_ . 'psgdpr_log` (
         INDEX (`id_customer`)
         ) ENGINE=' . _MYSQL_ENGINE_ . ' DEFAULT CHARSET=UTF8;';
 
-
-
 $sql[] = ' ALTER TABLE `' . _DB_PREFIX_ . 'psgdpr_log` 
-        ADD INDEX( `id_customer`, `id_guest`, `client_name`, `id_module`, `date_add`, `date_upd`); '
+        ADD INDEX `idx_id_customer` ( `id_customer`, `id_guest`, `client_name`, `id_module`, `date_add`, `date_upd`); ';
 
 foreach ($sql as $query) {
     if (Db::getInstance()->execute($query) == false) {

--- a/upgrade/upgrade-1.4.0.php
+++ b/upgrade/upgrade-1.4.0.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ */
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+/**
+ * @param Psgdpr $module
+ *
+ * @return bool
+ */
+function upgrade_module_1_4_0($module)
+{
+    $sql = ' ALTER TABLE `' . _DB_PREFIX_ . 'psgdpr_log` 
+        ADD INDEX `idx_id_customer` ( `id_customer`, `id_guest`, `client_name`, `id_module`, `date_add`, `date_upd`); ';
+
+    if (Db::getInstance()->execute($sql) == false) {
+        return false;
+    }
+
+    return true;
+}


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | [On this line of GDPRLog](https://github.com/PrestaShop/psgdpr/blob/7c79a99317f5be712f91933e753c60713fcc5fb5/classes/GDPRLog.php#L120) the module make a request without index. On our merchand we have more than 1.3M lines in this table. <br><br> Without index : 640ms ![image](https://user-images.githubusercontent.com/52157233/147964124-2746f1c3-9cd3-43d4-9c38-e2d747a99cc1.png)  <br> With index : 2ms <br>![image](https://user-images.githubusercontent.com/52157233/147964254-ccfefccf-20e0-4369-899c-93ecd1b86254.png)
| Type?         | improvement
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes PrestaShop/Prestashop#27178.
| How to test?  | Make an action that add log in the module.