### PR TITLE
Remove the deprecated method `Tools::jsonDecode`, Fix Reset & Bump to 1.4.1

### DIFF
--- a/classes/APIFAQClass.php
+++ b/classes/APIFAQClass.php
@@ -46,7 +46,7 @@ class APIFAQ
             return false;
         }
         /** @var object $content */
-        $content = Tools::jsonDecode($content, true);
+        $content = json_decode($content, true);
         if (empty($content->categories)) {
             return false;
         }

--- a/config.xml
+++ b/config.xml
@@ -2,7 +2,7 @@
 <module>
     <name>psgdpr</name>
     <displayName><![CDATA[Official GDPR compliance]]></displayName>
-    <version><![CDATA[1.4.0]]></version>
+    <version><![CDATA[1.4.1]]></version>
     <description><![CDATA[Make your store comply with the General Data Protection Regulation (GDPR).]]></description>
     <author><![CDATA[PrestaShop]]></author>
     <tab><![CDATA[front_office_features]]></tab>

--- a/psgdpr.php
+++ b/psgdpr.php
@@ -766,7 +766,7 @@ class Psgdpr extends Module
         $genderName = $gender->name;
         unset($gender);
 
-        $customerInfo = [
+        $data['customerInfo'] = [
             'id_customer' => $customer->id,
             'gender' => $genderName,
             'firstname' => $customer->firstname,
@@ -784,7 +784,7 @@ class Psgdpr extends Module
         ];
 
         // get orders
-        $orders = [];
+        $data['orders'] = [];
         $orderList = Order::getCustomerOrders($customer->id);
 
         if (count($orderList) >= 1) {
@@ -793,7 +793,7 @@ class Psgdpr extends Module
                 $productsOrder = $orderObject->getProducts();
                 $currency = Currency::getCurrency($order['id_currency']);
 
-                array_push($orders, [
+                $data['orders'][] = [
                     'id_order' => $order['id_order'],
                     'reference' => $order['reference'],
                     'payment' => $order['payment'],
@@ -803,22 +803,22 @@ class Psgdpr extends Module
                     'total_paid_tax_incl' => number_format($order['total_paid_tax_incl'], 2) . ' ' . $currency['iso_code'],
                     'nb_products' => $order['nb_products'],
                     'products' => [],
-                ]);
+                ];
                 foreach ($productsOrder as $product) {
-                    array_push($orders[$index]['products'], [
+                    $data['orders'][$index]['products'][] = [
                         'id_product' => $product['product_id'],
                         'id_product_attribute' => $product['product_attribute_id'],
                         'product_reference' => $product['product_reference'],
                         'product_name' => $product['product_name'],
                         'product_quantity' => $product['product_quantity'],
-                    ]);
+                    ];
                 }
                 unset($orderObject);
             }
         }
 
         // get carts
-        $carts = [];
+        $data['carts'] = [];
         $cartList = Cart::getCustomerCarts($customer->id, false);
 
         if (count($cartList) >= 1) {
@@ -826,57 +826,51 @@ class Psgdpr extends Module
                 $cartObject = new Cart($cart['id_cart']);
                 $productsCart = $cartObject->getProducts();
 
-                array_push($carts, [
+                $data['carts'][] = [
                     'id_cart' => $cart['id_cart'],
                     'nb_products' => count($productsCart),
                     'products' => [],
                     'date_add' => $cart['date_add'],
-                ]);
+                ];
                 foreach ($productsCart as $product) {
-                    array_push($carts[$index]['products'], [
+                    $data['carts'][$index]['products'][] = [
                         'id_product' => $product['id_product'],
                         'id_product_attribute' => $product['id_product_attribute'],
                         'product_reference' => $product['reference'],
                         'product_name' => $product['name'],
                         'product_quantity' => $product['cart_quantity'],
                         'total_wt' => $product['total_wt'],
-                    ]);
+                    ];
                 }
                 unset($cartObject);
             }
         }
 
         // get addresses
-        $addresses = $customer->getAddresses($id_lang);
+        $data['addresses'] = $customer->getAddresses($id_lang);
 
         // get messages
-        $messages = [];
+        $data['messages'] = [];
         $messageList = CustomerThread::getCustomerMessages($customer->id);
 
         if (count($messageList) >= 1) {
             foreach ($messageList as $index => $message) {
-                array_push($messages, [
+                $data['messages'][] = [
                     'id_customer_thread' => $message['id_customer_thread'],
                     'message' => $message['message'],
                     'ip' => (int) $message['ip_address'] == $message['ip_address'] ? long2ip((int) $message['ip_address']) : $message['ip_address'],
                     'date_add' => $message['date_add'],
-                ]);
+                ];
             }
         }
 
         // get connections
-        $connections = $customer->getLastConnections();
+        $data['connections'] = $customer->getLastConnections();
 
         // get referrers
-        $referrer = Referrer::getReferrers($customer->id);
-
-        $data['customerInfo'] = $customerInfo;
-        $data['orders'] = $orders;
-        $data['carts'] = $carts;
-        $data['addresses'] = $addresses;
-        $data['messages'] = $messages;
-        $data['connections'] = $connections;
-        $data['referrer'] = $referrer;
+        if (version_compare(_PS_VERSION_, '8.0.0', '<')) {
+            $data['referrer'] = Referrer::getReferrers($customer->id);
+        }
 
         return $data;
     }

--- a/psgdpr.php
+++ b/psgdpr.php
@@ -119,7 +119,7 @@ class Psgdpr extends Module
         // Settings
         $this->name = 'psgdpr';
         $this->tab = 'administration';
-        $this->version = '1.4.0';
+        $this->version = '1.4.1';
         $this->author = 'PrestaShop';
         $this->need_instance = 0;
 

--- a/sql/install.php
+++ b/sql/install.php
@@ -48,11 +48,9 @@ $sql[] = ' CREATE TABLE IF NOT EXISTS `' . _DB_PREFIX_ . 'psgdpr_log` (
         `date_add` datetime NOT NULL,
         `date_upd` datetime NOT NULL,
         PRIMARY KEY (`id_gdpr_log`),
-        INDEX (`id_customer`)
+        INDEX (`id_customer`),
+        INDEX `idx_id_customer` ( `id_customer`, `id_guest`, `client_name`, `id_module`, `date_add`, `date_upd`)
         ) ENGINE=' . _MYSQL_ENGINE_ . ' DEFAULT CHARSET=UTF8;';
-
-$sql[] = ' ALTER TABLE `' . _DB_PREFIX_ . 'psgdpr_log` 
-        ADD INDEX `idx_id_customer` ( `id_customer`, `id_guest`, `client_name`, `id_module`, `date_add`, `date_upd`); ';
 
 foreach ($sql as $query) {
     if (Db::getInstance()->execute($query) == false) {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Remove the deprecated method `Tools::jsonDecode`
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Relative to PrestaShop/Prestashop#27962
| How to test?  | * Install the module (my PR)<br>* Reset the module (no problem anymore)<br>* Go to configure page (no problem anymore)<br>* Release Test

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
