### PR TITLE
Bump to 1.4.2 and make sure password is correctly encoded

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -2,7 +2,7 @@
 <module>
     <name>psgdpr</name>
     <displayName><![CDATA[Official GDPR compliance]]></displayName>
-    <version><![CDATA[1.4.1]]></version>
+    <version><![CDATA[1.4.2]]></version>
     <description><![CDATA[Make your store comply with the General Data Protection Regulation (GDPR).]]></description>
     <author><![CDATA[PrestaShop]]></author>
     <tab><![CDATA[front_office_features]]></tab>

--- a/psgdpr.php
+++ b/psgdpr.php
@@ -122,7 +122,7 @@ class Psgdpr extends Module
         // Settings
         $this->name = 'psgdpr';
         $this->tab = 'administration';
-        $this->version = '1.4.1';
+        $this->version = '1.4.2';
         $this->author = 'PrestaShop';
         $this->need_instance = 0;
 

--- a/tests/phpstan/phpstan-1.7.1.2.neon
+++ b/tests/phpstan/phpstan-1.7.1.2.neon
@@ -7,5 +7,6 @@ parameters:
     - '#Parameter \#1 \$hook_name of method ModuleCore\:\:registerHook\(\) expects string, array<int, string> given.#'
     - '#Parameter \#1 \$id of class Customer constructor expects null, int given.#'
     - '#Parameter \#4 \$idShop of static method CMSCore\:\:getCMSPages\(\) expects null, int given.#'
-    - '#Parameter \#4 \$ssl of method LinkCore\:\:getModuleLink\(\) expects null, true given.#'
+    - '#Parameter \#4 \$ssl of method LinkCore\:\:getModuleLink\(\) expects null, true given\.#'
     - '#Property CustomerCore\:\:\$passwd \(int\) does not accept string.#'
+    - '#^Strict comparison using === between int and ''prestashop'' will always evaluate to false\.$#'

--- a/upgrade/upgrade-1.4.2.php
+++ b/upgrade/upgrade-1.4.2.php
@@ -32,7 +32,8 @@ use PrestaShop\PrestaShop\Core\Crypto\Hashing;
 function upgrade_module_1_4_2($module)
 {
     // Only change password when it's "prestashop"
-    $customer = new Customer(Configuration::get('PSGDPR_ANONYMOUS_CUSTOMER'));
+    $customer = new Customer((int) Configuration::get('PSGDPR_ANONYMOUS_CUSTOMER'));
+    // @phpstan-ignore-next-line
     if (Validate::isLoadedObject($customer) && $customer->passwd === 'prestashop') {
         /** @var Hashing $crypto */
         $crypto = ServiceLocator::get(Hashing::class);

--- a/upgrade/upgrade-1.4.2.php
+++ b/upgrade/upgrade-1.4.2.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ */
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+use PrestaShop\PrestaShop\Adapter\ServiceLocator;
+use PrestaShop\PrestaShop\Core\Crypto\Hashing;
+
+/**
+ * @param Psgdpr $module
+ *
+ * @return bool
+ */
+function upgrade_module_1_4_2($module)
+{
+    // Only change password when it's "prestashop"
+    $customer = new Customer(Configuration::get('PSGDPR_ANONYMOUS_CUSTOMER'));
+    if (Validate::isLoadedObject($customer) && $customer->passwd === 'prestashop') {
+        /** @var Hashing $crypto */
+        $crypto = ServiceLocator::get(Hashing::class);
+        $customer->passwd = $crypto->hash(Tools::passwdGen(64)); // Generate a long random password
+        $customer->save();
+    }
+
+    return true;
+}


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Bump to 1.4.2 and make sure password is correctly encoded.
| Type?         | improvement
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Make and upgrade with this one after changing the database field for the anonymous user by "prestashop".

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
