### PR TITLE
Fix anonymous user if it's already in database

### DIFF
--- a/psgdpr.php
+++ b/psgdpr.php
@@ -1054,7 +1054,7 @@ class Psgdpr extends Module
 
         if (isset($anonymousCustomer['id_customer'])) {
             if ($anonymousCustomer['passwd'] === 'prestashop') {
-                $customer = new Customer($anonymousCustomer['id_customer']);
+                $customer = new Customer((int) $anonymousCustomer['id_customer']);
                 $customer->passwd = $crypto->hash(Tools::passwdGen(64)); // Generate a long random password
                 $customer->save();
             }

--- a/psgdpr.php
+++ b/psgdpr.php
@@ -1046,10 +1046,19 @@ class Psgdpr extends Module
      */
     public function createAnonymousCustomer()
     {
-        $query = 'SELECT id_customer, email FROM `' . _DB_PREFIX_ . 'customer` c WHERE email = "anonymous@psgdpr.com" or email = "anonymous@anonymous.com"';
+        /** @var Hashing $crypto */
+        $crypto = ServiceLocator::get(Hashing::class);
+
+        $query = 'SELECT id_customer, email, passwd FROM `' . _DB_PREFIX_ . 'customer` c WHERE email = "anonymous@psgdpr.com" or email = "anonymous@anonymous.com"';
         $anonymousCustomer = Db::getInstance()->getRow($query);
 
         if (isset($anonymousCustomer['id_customer'])) {
+            if ($anonymousCustomer['passwd'] === 'prestashop') {
+                $customer = new Customer($anonymousCustomer['id_customer']);
+                $customer->passwd = $crypto->hash(Tools::passwdGen(64)); // Generate a long random password
+                $customer->save();
+            }
+
             $id_address = Address::getFirstCustomerAddressId($anonymousCustomer['id_customer']);
 
             Configuration::updateValue('PSGDPR_ANONYMOUS_CUSTOMER', $anonymousCustomer['id_customer']);
@@ -1057,9 +1066,6 @@ class Psgdpr extends Module
 
             return true;
         }
-
-        /** @var Hashing $crypto */
-        $crypto = ServiceLocator::get(Hashing::class);
 
         // create an anonymous customer
         $customer = new Customer();


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | If the user exists in the database and we try to reinstall the module, it will change the anonymous password by a real unknown password.
| Type?         | bug fix
| How to test?  | ```UPDATE `ps_customer` SET`passwd` = 'prestashop' WHERE `ps_customer`.`email` = 'anonymous@psgdpr.com';``` then try to uninstall & install the module


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
