### PR TITLE
Remove id of the div to avoid duplications

### DIFF
--- a/views/templates/hook/displayGDPRConsent.tpl
+++ b/views/templates/hook/displayGDPRConsent.tpl
@@ -17,7 +17,7 @@
  * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
  *}
 
-<div id="gdpr_consent" class="gdpr_module_{$psgdpr_id_module|escape:'htmlall':'UTF-8'}">
+<div class="gdpr_consent gdpr_module_{$psgdpr_id_module|escape:'htmlall':'UTF-8'}">
     <span class="custom-checkbox">
         <label class="psgdpr_consent_message">
             <input id="psgdpr_consent_checkbox_{$psgdpr_id_module|escape:'htmlall':'UTF-8'}" name="psgdpr_consent_checkbox" type="checkbox" value="1" class="psgdpr_consent_checkboxes_{$psgdpr_id_module|escape:'htmlall':'UTF-8'}">


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Having duplicated ids is invalid HTML
| Type?         | bug fix
| BC breaks?    | yes
| Deprecations? |no
| Fixed ticket? | Fixes PrestaShop/Prestashop#23312.
| How to test?  | You need to have two consents on the same page, make sure that there are no duplicated IDs anymore. Details in the Issue.
| Sponsor company | impSolutions

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

**Important** I will update `ps_emailalerts` module because it is a breaking change for third-party modules.
