### PR TITLE
Fix age from export customer info

### DIFF
--- a/psgdpr.php
+++ b/psgdpr.php
@@ -1145,6 +1145,6 @@ class Psgdpr extends Module
             AND id_customer = ' . (int) $id_customer . '
             AND birthday IS NOT NULL AND birthday != "0000-00-00" ' . Shop::addSqlRestriction());
 
-        return (int) round($value / 365);
+        return (int) floor($value / 365);
     }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | When downloading my GDPR Personal data to PDF or CSV, I can see that the age displayed is not correct.
It is my current age + 1.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes PrestaShop/Prestashop#29074.
| How to test?  | See issue

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
