### PR TITLE
Avoid JS error

### DIFF
--- a/views/js/front.js
+++ b/views/js/front.js
@@ -18,6 +18,8 @@
  */
 
 $(document).ready(function() {
+    formatGdprForm();
+    
     psgdpr_front_controller = psgdpr_front_controller.replace(/\amp;/g,'');
 
     $(document).on('click', '#exportPersonalData', function (e) {

--- a/views/templates/hook/displayGDPRConsent.tpl
+++ b/views/templates/hook/displayGDPRConsent.tpl
@@ -36,7 +36,7 @@
     var psgdpr_id_guest = "{/literal}{$psgdpr_id_guest|escape:'htmlall':'UTF-8'}{literal}";
     var psgdpr_guest_token = "{/literal}{$psgdpr_guest_token|escape:'htmlall':'UTF-8'}{literal}";
 
-    document.addEventListener('DOMContentLoaded', function() {
+    function formatGdprForm() {
         let psgdpr_id_module = "{/literal}{$psgdpr_id_module|escape:'htmlall':'UTF-8'}{literal}";
         let parentForm = $('.gdpr_module_' + psgdpr_id_module).closest('form');
 
@@ -80,7 +80,7 @@
                     console.log(err);
                 }
             });
-        });
+        };
     });
 </script>
 {/literal}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Sometimes the function is executed before jQuery is loaded, and an error appears: ![image](https://user-images.githubusercontent.com/15104724/204284589-4946479a-cf3e-45e2-9cf0-515bc01ae5a0.png)
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes PrestaShop/Prestashop#30306
| How to test?  | It's difficult to test as it does not happen always. I caught it in Sentry. But it's a "logic" error. This function was fired on `DOMContentLoaded` and not in `$(document).ready`, so could be that the jQuery library is not loaded yet.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
