### PR TITLE
Fix hook registration if needed

### DIFF
--- a/psgdpr.php
+++ b/psgdpr.php
@@ -566,6 +566,7 @@ class Psgdpr extends Module
                 $label = Configuration::get('PSGDPR_CUSTOMER_FORM', $id_lang);
                 break;
             case 'authentication':
+            case 'registration':
             case 'order':
             case 'order-confirmation':
                 $active = Configuration::get('PSGDPR_CREATION_FORM_SWITCH');

--- a/psgdpr.php
+++ b/psgdpr.php
@@ -904,6 +904,7 @@ class Psgdpr extends Module
 
         // get referrers
         if (version_compare(_PS_VERSION_, '8.0.0', '<')) {
+            // @phpstan-ignore-next-line
             $data['referrer'] = Referrer::getReferrers($customer->id);
         }
 

--- a/upgrade/upgrade-1.4.3.php
+++ b/upgrade/upgrade-1.4.3.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ */
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+/**
+ * @param Psgdpr $module
+ *
+ * @return bool
+ */
+function upgrade_module_1_4_3($module)
+{
+    if (!$module->isRegisteredInHook('displayGDPRConsent')) {
+        return $module->registerHook('displayGDPRConsent');
+    }
+
+    return true;
+}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Sometimes hook wasn't registered. This PR adds a migration script from v1.4.2 to v1.4.3 that performs the following logic: "if the hook displayGDPRConsent was not registered for this module, I register it"
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes PrestaShop/Prestashop#30348.
| How to test?  | Please see ticket. You need a usecase where GDPR module is installed (v1.4.2) and the hook displayGDPRConsent is not registered for the module. See if checkboxes are displayed after GDPR upgrade module to 1.4.3.
| Sponsor company | impSolutions

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
