### PR TITLE
remove isset condition because variables always set

### DIFF
--- a/controllers/front/FrontAjaxGdpr.php
+++ b/controllers/front/FrontAjaxGdpr.php
@@ -48,7 +48,7 @@ class psgdprFrontAjaxGdprModuleFrontController extends FrontController
             }
         } else {
             $token = sha1('psgdpr' . Context::getContext()->cart->id_guest . $_SERVER['REMOTE_ADDR'] . date('Y-m-d'));
-            if ($guest_token == $token) {
+            if ($guest_token === $token) {
                 GDPRLog::addLog($id_customer, 'consent', $id_module, $id_guest);
             }
         }

--- a/controllers/front/FrontAjaxGdpr.php
+++ b/controllers/front/FrontAjaxGdpr.php
@@ -43,12 +43,12 @@ class psgdprFrontAjaxGdprModuleFrontController extends FrontController
 
         if ($customer->isLogged() === true) {
             $token = sha1($customer->secure_key);
-            if (!isset($customer_token) || $customer_token == $token) {
+            if ($customer_token == $token) {
                 GDPRLog::addLog($id_customer, 'consent', $id_module);
             }
         } else {
             $token = sha1('psgdpr' . Context::getContext()->cart->id_guest . $_SERVER['REMOTE_ADDR'] . date('Y-m-d'));
-            if (!isset($guest_token) || $guest_token == $token) {
+            if ($guest_token == $token) {
                 GDPRLog::addLog($id_customer, 'consent', $id_module, $id_guest);
             }
         }

--- a/controllers/front/FrontAjaxGdpr.php
+++ b/controllers/front/FrontAjaxGdpr.php
@@ -43,7 +43,7 @@ class psgdprFrontAjaxGdprModuleFrontController extends FrontController
 
         if ($customer->isLogged() === true) {
             $token = sha1($customer->secure_key);
-            if ($customer_token == $token) {
+            if ($customer_token === $token) {
                 GDPRLog::addLog($id_customer, 'consent', $id_module);
             }
         } else {


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | In front ajax gdpr controller there is a condition to prove that a variable is set. but the variables are always set.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | See if consents are properly logged to BO

