### PR TITLE
Handle both legacy & symfony customer routes

### DIFF
--- a/psgdpr.php
+++ b/psgdpr.php
@@ -445,6 +445,7 @@ class Psgdpr extends Module
 
         // assign var to smarty
         $this->context->smarty->assign([
+            'customer_link' => $this->context->link->getAdminLink('AdminCustomers', true) . '&viewcustomer&id_customer=',
             'module_name' => $this->name,
             'id_shop' => $id_shop,
             'module_version' => $this->version,

--- a/psgdpr.php
+++ b/psgdpr.php
@@ -445,7 +445,7 @@ class Psgdpr extends Module
 
         // assign var to smarty
         $this->context->smarty->assign([
-            'customer_link' => $this->context->link->getAdminLink('AdminCustomers', true) . '&viewcustomer&id_customer=',
+            'customer_link' => $this->context->link->getAdminLink('AdminCustomers', true, [], ['viewcustomer' => '', 'id_customer' => 0]),
             'module_name' => $this->name,
             'id_shop' => $id_shop,
             'module_version' => $this->version,

--- a/views/templates/admin/menu.tpl
+++ b/views/templates/admin/menu.tpl
@@ -66,7 +66,7 @@
     var psgdpr_adminController = "{$psgdpr_adminController|escape:'htmlall':'UTF-8'}";
     var adminControllerInvoices = "{$adminControllerInvoices|escape:'htmlall':'UTF-8'}";
     var ps_version = "{$isPs17|escape:'htmlall':'UTF-8'}";
-    var customer_link = "{url entity='sf' route='admin_customers_view' sf-params=['customerId' => '0']}";
+    var customer_link = "{$customer_link|escape:'htmlall':'UTF-8'}";
 
     var messageSuccessCopy = "{l s='Url has been copied to the clipboard!' mod='psgdpr' js=1}";
     var messageSuccessInvoices = "{l s='Invoices have been successfully downloaded.' mod='psgdpr' js=1}";

--- a/views/templates/admin/tabs/dataConfig.tpl
+++ b/views/templates/admin/tabs/dataConfig.tpl
@@ -122,7 +122,7 @@
                         <span class="text-muted">{l s='Orders number' mod='psgdpr'}: (( customer.nb_orders ))</span>
                     </div>
                     <div class="panel-footer">
-                        <a v-on:click.stop :href="customer_link.replace(/\/0\//,'/'+customer.id_customer+'/')" target="_blank" class="btn btn-default fancybox"><i class="icon-search"></i> {l s='Details' mod='psgdpr'}</a>
+                        <a v-on:click.stop :href="customer_link+customer.id_customer" target="_blank" class="btn btn-default fancybox"><i class="icon-search"></i> {l s='Details' mod='psgdpr'}</a>
                         <button type="button" v-on:click.stop="deleteCustomer('customer', customer.id_customer, index)" class="btn btn-danger pull-right"><i class="icon-trash"></i> {l s='Remove data' mod='psgdpr'}</button>
                         <a v-on:click.stop="downloadInvoices(customer.id_customer, index)" class="btn btn-primary pull-right"><i class="icon-download"></i> {l s='Download invoices' mod='psgdpr'}</a>
                     </div>

--- a/views/templates/admin/tabs/dataConfig.tpl
+++ b/views/templates/admin/tabs/dataConfig.tpl
@@ -122,7 +122,7 @@
                         <span class="text-muted">{l s='Orders number' mod='psgdpr'}: (( customer.nb_orders ))</span>
                     </div>
                     <div class="panel-footer">
-                        <a v-on:click.stop :href="customer_link+customer.id_customer" target="_blank" class="btn btn-default fancybox"><i class="icon-search"></i> {l s='Details' mod='psgdpr'}</a>
+                        <a v-on:click.stop :href="customer_link.replace(/(id_customer=|customers\/)0/gi, '$1'+customer.id_customer)" target="_blank" class="btn btn-default fancybox"><i class="icon-search"></i> {l s='Details' mod='psgdpr'}</a>
                         <button type="button" v-on:click.stop="deleteCustomer('customer', customer.id_customer, index)" class="btn btn-danger pull-right"><i class="icon-trash"></i> {l s='Remove data' mod='psgdpr'}</button>
                         <a v-on:click.stop="downloadInvoices(customer.id_customer, index)" class="btn btn-primary pull-right"><i class="icon-download"></i> {l s='Download invoices' mod='psgdpr'}</a>
                     </div>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Since #122, only the new Symfony route for customers was handled, leading in errors for older PrestaShop versions. This PR aims to fix it by handling both cases.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes PrestaShop/Prestashop#31001
| How to test?  | Please see #31001

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
