### PR TITLE
Removing require autoload.php in psgdpr.php and version bumping

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -2,7 +2,7 @@
 <module>
     <name>psgdpr</name>
     <displayName><![CDATA[Official GDPR compliance]]></displayName>
-    <version><![CDATA[2.0.0]]></version>
+    <version><![CDATA[2.0.1]]></version>
     <description><![CDATA[Make your store comply with the General Data Protection Regulation (GDPR).]]></description>
     <author><![CDATA[PrestaShop]]></author>
     <tab><![CDATA[front_office_features]]></tab>

--- a/psgdpr.php
+++ b/psgdpr.php
@@ -87,7 +87,7 @@ class Psgdpr extends Module
     {
         $this->name = 'psgdpr';
         $this->tab = 'administration';
-        $this->version = '2.0.0';
+        $this->version = '2.0.1';
         $this->author = 'PrestaShop';
         $this->need_instance = 0;
 

--- a/psgdpr.php
+++ b/psgdpr.php
@@ -104,8 +104,6 @@ class Psgdpr extends Module
 
         $this->confirmUninstall = $this->trans('Are you sure you want to uninstall this module?', [], 'Modules.Psgdpr.Shop');
         $this->ps_versions_compliancy = ['min' => '8.0.0', 'max' => _PS_VERSION_];
-
-        require_once __DIR__ . '/vendor/autoload.php';
     }
 
     /**


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | The new system requires autoload directly from the CORE, then we should remove require autoload in psgdpr.php
Version bumping as well
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | This should be solve CI error here https://github.com/PrestaShop/PrestaShop/pull/32083

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
