### PR TITLE
fix: set id gdpr consent in add module consent

### DIFF
--- a/psgdpr.php
+++ b/psgdpr.php
@@ -564,6 +564,7 @@ class Psgdpr extends Module
 
         $psgdprConsent = new PsgdprConsent();
         $psgdprConsent->setModuleId($module['id_module']);
+        $psgdprConsent->setId($module['id_gdpr_consent']);
         $psgdprConsent->setActive(true);
 
         /** @var Lang $language */


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | fix error on insert into psgdpr_consent when id_psgdpr_consent is not set
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | set custom database prefix, setup DB and use autoupgrade.
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
