### PR TITLE
Fix small typo in English dataConsent.tpl

### DIFF
--- a/views/templates/admin/tabs/dataConsent.tpl
+++ b/views/templates/admin/tabs/dataConsent.tpl
@@ -198,7 +198,7 @@
                     <div class="col-xs-12 col-sm-12 col-md-7 col-lg-6">
                         <textarea class="autoload_rte" name="psgdpr_registered_module_{$module.id_module|escape:'htmlall':'UTF-8'}_{$language.id_lang|escape:'htmlall':'UTF-8'}" text="" rows="4" cols="80">{$module.message[$language.id_lang]|escape:'htmlall':'UTF-8'}</textarea>
                         <div class="help-block">
-                            <p>{l s='This message will be accomplanied by a checkbox' d='Modules.Psgdpr.Admin'}</p>
+                            <p>{l s='This message will be accompanied by a checkbox' d='Modules.Psgdpr.Admin'}</p>
                         </div>
                     </div>
                     {if $languages|count > 1}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Change typo
| Type?             | typo fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | N/A
| Sponsor company   | PS
| How to test?      | Check help text in Consent checkbox customization

**Before :**
<img width="802" alt="Screenshot 2023-10-19 at 14 36 48" src="https://github.com/PrestaShop/psgdpr/assets/16019289/28a66745-c7f6-4b98-be3a-b22653eb8790">

**After :**
<img width="802" alt="Screenshot 2023-10-19 at 14 36 18" src="https://github.com/PrestaShop/psgdpr/assets/16019289/42aff7a1-34e5-48fa-9e18-e61162826ee2">
