### PR TITLE
Remove unneeded version check

### DIFF
--- a/controllers/front/gdpr.php
+++ b/controllers/front/gdpr.php
@@ -59,7 +59,6 @@ class psgdprgdprModuleFrontController extends ModuleFrontController
             'psgdpr_front_controller' => Context::getContext()->link->getModuleLink('psgdpr', 'gdpr', $params, true),
             'psgdpr_csv_controller' => Context::getContext()->link->getModuleLink('psgdpr', 'ExportCustomerData', array_merge(['type' => 'csv'], $params), true),
             'psgdpr_pdf_controller' => Context::getContext()->link->getModuleLink('psgdpr', 'ExportCustomerData', array_merge(['type' => 'pdf'], $params), true),
-            'psgdpr_ps_version' => (bool) version_compare(_PS_VERSION_, '1.7', '>='),
             'psgdpr_id_customer' => Context::getContext()->customer->id,
         ]);
 

--- a/src/Controller/Admin/CustomerController.php
+++ b/src/Controller/Admin/CustomerController.php
@@ -78,7 +78,7 @@ class CustomerController extends FrameworkBundleAdminController
         $requestBodyContent = json_decode($request->getContent(), true);
         $phrase = $requestBodyContent['phrase'];
 
-        if (!isset($phrase) && empty($phrase)) {
+        if (empty($phrase)) {
             return $this->json(['message' => 'Property phrase is missing or empty.'], Response::HTTP_BAD_REQUEST);
         }
 

--- a/views/templates/front/account_gdpr_page.tpl
+++ b/views/templates/front/account_gdpr_page.tpl
@@ -41,7 +41,6 @@
 <script type="text/javascript">
     var psgdpr_front_controller = "{/literal}{$psgdpr_front_controller|escape:'htmlall':'UTF-8'}{literal}";
     var psgdpr_id_customer = "{/literal}{$psgdpr_front_controller|escape:'htmlall':'UTF-8'}{literal}";
-    var psgdpr_ps_version = "{/literal}{$psgdpr_ps_version|escape:'htmlall':'UTF-8'}{literal}";
 </script>
 {/literal}
 {/block}


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Removes forgotten version check. Minimum core version is higher than what this check is doing. Fixed one typo that was breaking PHPStan.
| Type?         | refacto
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | No need, syntax is covered by tests.