### PR TITLE
Include id_shop in the primary key on table psgdpr_consent_lang

### DIFF
--- a/src/Entity/PsgdprConsentLang.php
+++ b/src/Entity/PsgdprConsentLang.php
@@ -54,6 +54,7 @@ class PsgdprConsentLang
 
     /**
      * @var int
+     * @ORM\Id
      * @ORM\Column(name="id_shop", type="integer", length=10, nullable=false)
      */
     private $shopId;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | In the table psgdpr_consent_lang, the field id_shop is included in the primary key (see `sql/install/psgdpr_consent_lang.sql`). The Doctrine/ORM annotations must reflect this. Add id_shop in PK in annotations
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes PrestaShop/PrestaShop#35521
| Sponsor company   | Société Biblique de Genève
| How to test?      | Run `php bin/console doctrine:schema:update --dump-sql` before and after. Notice that the incorrect query concerning the PK of psgdpr_consent_lang disappears.
