### PR TITLE
Show customer ID and anonymize data in the Customer Activity Log

### DIFF
--- a/config/services.yml
+++ b/config/services.yml
@@ -36,6 +36,7 @@ services:
       - "@prestashop.core.query_bus"
       - "@prestashop.adapter.group.provider.default_groups_provider"
       - "@hashing"
+      - "@PrestaShop\\Module\\Psgdpr\\Repository\\LoggerRepository"
 
   PrestaShop\Module\Psgdpr\Service\Export\Strategy\ExportToCsv:
     class: 'PrestaShop\Module\Psgdpr\Service\Export\Strategy\ExportToCsv'

--- a/src/Service/BackResponder/Strategy/BackResponderByCustomerId.php
+++ b/src/Service/BackResponder/Strategy/BackResponderByCustomerId.php
@@ -64,8 +64,10 @@ class BackResponderByCustomerId extends BackResponderContext implements BackResp
 
         $this->customerService->deleteCustomerDataFromPrestashop($customerId);
         $this->customerService->deleteCustomerDataFromModules(strval($customerId->getValue()));
+        $this->customerService->deleteCustomerDataFromGDPRModule($customerId);
 
-        $this->loggerService->createLog($customerId->getValue(), LoggerService::REQUEST_TYPE_DELETE, 0, 0, $customerData);
+        // Store customer ID as 0 to avoid connecting previously anonymized records with customer's name by ID
+        $this->loggerService->createLog(0, LoggerService::REQUEST_TYPE_DELETE, 0, 0, $customerData);
 
         return new JsonResponse(['message' => 'delete completed']);
     }

--- a/views/templates/admin/tabs/customerActivity.tpl
+++ b/views/templates/admin/tabs/customerActivity.tpl
@@ -36,7 +36,7 @@
          <tbody>
              {foreach from=$logs item=log}
                <tr>
-                 <td class="text-center">{$log.client_name|escape:'htmlall':'UTF-8'}</td>
+                 <td class="text-center">{$log.client_name|escape:'htmlall':'UTF-8'} (ID: {$log.id_customer|escape:'htmlall':'UTF-8'})</td>
                  {if $log.request_type eq 1}
                  <td class="text-center">{l s='Consent confirmation' d='Modules.Psgdpr.Admin'}</td>
                  {/if}

--- a/views/templates/admin/tabs/customerActivity.tpl
+++ b/views/templates/admin/tabs/customerActivity.tpl
@@ -36,7 +36,7 @@
          <tbody>
              {foreach from=$logs item=log}
                <tr>
-                 <td class="text-center">{$log.client_name|escape:'htmlall':'UTF-8'} (ID: {$log.id_customer|escape:'htmlall':'UTF-8'})</td>
+                 <td class="text-center">{$log.client_name|escape:'htmlall':'UTF-8'}{if $log.id_customer neq 0} (ID: {$log.id_customer|escape:'htmlall':'UTF-8'}){/if}</td>
                  {if $log.request_type eq 1}
                  <td class="text-center">{l s='Consent confirmation' d='Modules.Psgdpr.Admin'}</td>
                  {/if}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Added customer ID to the customer data column in the Customer Activity Log (if it is not 0). Implemented anonymization of logs in case of GDPR data deletion. Removed customer ID from erasure request (to avoid connecting customer name with previous account ID and records). The name should be retained in logs for compliance proof and for detecting excess requests.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes PrestaShop/PrestaShop#34265 , Fixes PrestaShop/PrestaShop#34266
| Sponsor company   | -
| How to test?      | 1. Create a new customer account. 2. Request personal data (one or a few times) from the user settings. 3. Check GDPR logs - customer ID should be shown. 4. Delete user data. 5. Recheck GDPR logs - old records shouldn't contain name and the erasure record shouldn't contain customer ID.
