### PR TITLE
Fix psgdpr menu URL query separator

### DIFF
--- a/psgdpr.php
+++ b/psgdpr.php
@@ -25,6 +25,7 @@ use PrestaShop\Module\Psgdpr\Repository\ConsentRepository;
 use PrestaShop\Module\Psgdpr\Repository\LoggerRepository;
 use PrestaShop\Module\Psgdpr\Service\LoggerService;
 use PrestaShop\PrestaShop\Adapter\LegacyLogger;
+use PrestaShop\PrestaShop\Core\Feature\TokenInUrls;
 use PrestaShopBundle\Entity\Lang;
 use PrestaShopBundle\Entity\Repository\LangRepository;
 use PrestaShopBundle\Service\Routing\Router;
@@ -366,6 +367,10 @@ class Psgdpr extends Module
      */
     public function getTokenFromAdminLink(string $link): string
     {
+        if (TokenInUrls::isDisabled()) {
+            return '';
+        }
+
         parse_str((string) parse_url($link, PHP_URL_QUERY), $result);
 
         if (is_array($result['_token'])) {

--- a/psgdpr.php
+++ b/psgdpr.php
@@ -25,7 +25,6 @@ use PrestaShop\Module\Psgdpr\Repository\ConsentRepository;
 use PrestaShop\Module\Psgdpr\Repository\LoggerRepository;
 use PrestaShop\Module\Psgdpr\Service\LoggerService;
 use PrestaShop\PrestaShop\Adapter\LegacyLogger;
-use PrestaShop\PrestaShop\Core\Feature\TokenInUrls;
 use PrestaShopBundle\Entity\Lang;
 use PrestaShopBundle\Entity\Repository\LangRepository;
 use PrestaShopBundle\Service\Routing\Router;
@@ -312,9 +311,10 @@ class Psgdpr extends Module
             'id_shop' => $id_shop,
             'module_version' => $this->version,
             'moduleAdminLink' => $moduleAdminLink,
+            'link' => $this->context->link,
             'id_lang' => $id_lang,
             'api_controller' => $this->getAdminLinkWithoutToken($apiController),
-            'admin_token' => $this->getTokenFromAdminLink($apiController),
+            'admin_token' => Tools::getAdminTokenLite('AdminModules'),
             'faq' => $this->loadFaq(),
             'doc' => $this->getReadmeByLang($isoLang),
             'youtubeLink' => $this->getYoutubeLinkByLang($isoLang),
@@ -356,28 +356,6 @@ class Psgdpr extends Module
         }
 
         return substr($link, 0, $pos);
-    }
-
-    /**
-     * Get token from an admin controller link
-     *
-     * @param string $link
-     *
-     * @return string
-     */
-    public function getTokenFromAdminLink(string $link): string
-    {
-        if (TokenInUrls::isDisabled()) {
-            return '';
-        }
-
-        parse_str((string) parse_url($link, PHP_URL_QUERY), $result);
-
-        if (is_array($result['_token'])) {
-            throw new \PrestaShopException('Invalid token');
-        }
-
-        return $result['_token'];
     }
 
     /**

--- a/views/js/menu.js
+++ b/views/js/menu.js
@@ -19,10 +19,10 @@
 $(window).ready(function () {
   moduleAdminLink = moduleAdminLink.replace(/\amp;/g, "");
 
-  function addQueryParameter(url, parameter) {
-    var separator = url.indexOf("?") === -1 ? "?" : "&";
-
-    return url + separator + parameter;
+  function setQueryParameter(url, key, value) {
+    const u = new URL(url, window.location.origin);
+    u.searchParams.set(key, value);
+    return u.toString();
   }
 
   window.vMenu = new Vue({
@@ -33,7 +33,7 @@ $(window).ready(function () {
     methods: {
       makeActive: function (item) {
         this.selectedTabName = item;
-        window.history.pushState({}, "", addQueryParameter(moduleAdminLink, "page=" + item));
+        window.history.pushState({}, "", setQueryParameter(moduleAdminLink, "page", item));
       },
       isActive: function (item) {
         if (this.selectedTabName == item) {

--- a/views/js/menu.js
+++ b/views/js/menu.js
@@ -19,6 +19,12 @@
 $(window).ready(function () {
   moduleAdminLink = moduleAdminLink.replace(/\amp;/g, "");
 
+  function addQueryParameter(url, parameter) {
+    var separator = url.indexOf("?") === -1 ? "?" : "&";
+
+    return url + separator + parameter;
+  }
+
   window.vMenu = new Vue({
     el: "#psgdpr-menu",
     data: {
@@ -27,7 +33,7 @@ $(window).ready(function () {
     methods: {
       makeActive: function (item) {
         this.selectedTabName = item;
-        window.history.pushState({}, "", moduleAdminLink + "&page=" + item);
+        window.history.pushState({}, "", addQueryParameter(moduleAdminLink, "page=" + item));
       },
       isActive: function (item) {
         if (this.selectedTabName == item) {

--- a/views/templates/admin/tabs/dataConfig.tpl
+++ b/views/templates/admin/tabs/dataConfig.tpl
@@ -13,15 +13,19 @@
  * to license@prestashop.com so we can send you a copy immediately.
  *
  * @author    PrestaShop SA <contact@prestashop.com>
- * @copyright Since 2007 PrestaShop SA and Contributors
- * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
- *}
+* @copyright Since 2007 PrestaShop SA and Contributors
+* @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+*}
+{assign var='querySeparator' value='?'}
+{if strpos($moduleAdminLink, '?') !== false}
+    {assign var='querySeparator' value='&'}
+{/if}
 
 <div class="panel col-lg-10 right-panel">
     <h3>
         <i class="fa fa-cogs"></i> {l s='Data visualization and automatic actions' d='Modules.Psgdpr.Admin'} <small>{$module_display|escape:'htmlall':'UTF-8'}</small>
     </h3>
-    <form method="post" action="{$moduleAdminLink|escape:'htmlall':'UTF-8'}&page=account" class="form-horizontal">
+    <form method="post" action="{$moduleAdminLink|escape:'htmlall':'UTF-8'}{$querySeparator|escape:'htmlall':'UTF-8'}page=account" class="form-horizontal">
         <div>
             <p>{l s='Find here listed all personal data collected by PrestaShop and your installed modules.' d='Modules.Psgdpr.Admin'}</p>
             <p>{l s='These data will be used at 2 different levels :' d='Modules.Psgdpr.Admin'}</p>

--- a/views/templates/admin/tabs/dataConfig.tpl
+++ b/views/templates/admin/tabs/dataConfig.tpl
@@ -16,16 +16,11 @@
 * @copyright Since 2007 PrestaShop SA and Contributors
 * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
 *}
-{assign var='querySeparator' value='?'}
-{if strpos($moduleAdminLink, '?') !== false}
-    {assign var='querySeparator' value='&'}
-{/if}
-
 <div class="panel col-lg-10 right-panel">
     <h3>
         <i class="fa fa-cogs"></i> {l s='Data visualization and automatic actions' d='Modules.Psgdpr.Admin'} <small>{$module_display|escape:'htmlall':'UTF-8'}</small>
     </h3>
-    <form method="post" action="{$moduleAdminLink|escape:'htmlall':'UTF-8'}{$querySeparator|escape:'htmlall':'UTF-8'}page=account" class="form-horizontal">
+    <form method="post" action="{$link->getAdminLink('AdminModules', true, [], ['configure' => 'psgdpr', 'page' => 'account'])|escape:'htmlall':'UTF-8'}" class="form-horizontal">
         <div>
             <p>{l s='Find here listed all personal data collected by PrestaShop and your installed modules.' d='Modules.Psgdpr.Admin'}</p>
             <p>{l s='These data will be used at 2 different levels :' d='Modules.Psgdpr.Admin'}</p>

--- a/views/templates/admin/tabs/dataConsent.tpl
+++ b/views/templates/admin/tabs/dataConsent.tpl
@@ -16,15 +16,11 @@
 * @copyright Since 2007 PrestaShop SA and Contributors
 * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
 *}
-{assign var='querySeparator' value='?'}
-{if strpos($moduleAdminLink, '?') !== false}
-    {assign var='querySeparator' value='&'}
-{/if}
 <div class="panel col-lg-10 right-panel">
     <h3>
         <i class="fa fa-wrench"></i> {l s='Configure your checkboxes' d='Modules.Psgdpr.Admin'} <small>{$module_display|escape:'htmlall':'UTF-8'}</small>
     </h3>
-    <form method="post" action="{$moduleAdminLink|escape:'htmlall':'UTF-8'}{$querySeparator|escape:'htmlall':'UTF-8'}page=dataConsent" class="form-horizontal">
+    <form method="post" action="{$link->getAdminLink('AdminModules', true, [], ['configure' => 'psgdpr', 'page' => 'dataConsent'])|escape:'htmlall':'UTF-8'}" class="form-horizontal">
         <div>
             <p>{l s='Please customize your consent request messages in the dedicated fields below :' d='Modules.Psgdpr.Admin'}</p>
             <article class="alert alert-info" role="alert" data-alert="info">

--- a/views/templates/admin/tabs/dataConsent.tpl
+++ b/views/templates/admin/tabs/dataConsent.tpl
@@ -13,14 +13,18 @@
  * to license@prestashop.com so we can send you a copy immediately.
  *
  * @author    PrestaShop SA <contact@prestashop.com>
- * @copyright Since 2007 PrestaShop SA and Contributors
- * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
- *}
+* @copyright Since 2007 PrestaShop SA and Contributors
+* @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+*}
+{assign var='querySeparator' value='?'}
+{if strpos($moduleAdminLink, '?') !== false}
+    {assign var='querySeparator' value='&'}
+{/if}
 <div class="panel col-lg-10 right-panel">
     <h3>
         <i class="fa fa-wrench"></i> {l s='Configure your checkboxes' d='Modules.Psgdpr.Admin'} <small>{$module_display|escape:'htmlall':'UTF-8'}</small>
     </h3>
-    <form method="post" action="{$moduleAdminLink|escape:'htmlall':'UTF-8'}&page=dataConsent" class="form-horizontal">
+    <form method="post" action="{$moduleAdminLink|escape:'htmlall':'UTF-8'}{$querySeparator|escape:'htmlall':'UTF-8'}page=dataConsent" class="form-horizontal">
         <div>
             <p>{l s='Please customize your consent request messages in the dedicated fields below :' d='Modules.Psgdpr.Admin'}</p>
             <article class="alert alert-info" role="alert" data-alert="info">


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | This fixes the BO module configuration URL when BO tokens are disabled.<br/>Previously, the `page` query parameter was always appended using `&`, which produced an invalid URL when no query string was present yet.<br/><br/>Example:<br/>- before: `/admin/improve/modules/manage/action/configure/psgdpr&page=dataConfig`<br/>- after: `/admin/improve/modules/manage/action/configure/psgdpr?page=dataConfig`<br/><br/>When a token is present, the existing behavior is preserved:<br/>- `/admin/improve/modules/manage/action/configure/psgdpr?_token=xxx&page=dataConfig`<br/><br/>In addition to fixing the query separator for module configuration URLs, it also:<br/>- fixes `dataConsent.tpl` and `dataConfig.tpl` form actions so they use the proper query separator depending on whether the base admin URL already contains a query string<br/>- makes `Psgdpr::getTokenFromAdminLink()` return an empty string when `TokenInUrls::isDisabled()` is enabled, to avoid relying on a token that is not present in the URL
| Type?             | bug fix 
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/psgdpr/issues/241 - https://github.com/PrestaShop/PrestaShop/issues/41314
| Sponsor company   | Codencode snc
| How to test?      | 1. Go to Advanced Parameters -> Security<br/>2. Disable BO tokens<br/>3. Open a module<br/> 4. Submit the configuration page form
