### PR TITLE
Create the consent rows when the module is installed, not when its page is opened

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -2,7 +2,7 @@
 <module>
     <name>psgdpr</name>
     <displayName><![CDATA[Official GDPR compliance]]></displayName>
-    <version><![CDATA[2.0.3]]></version>
+    <version><![CDATA[2.0.4]]></version>
     <description><![CDATA[Make your store comply with the General Data Protection Regulation (GDPR).]]></description>
     <author><![CDATA[PrestaShop]]></author>
     <tab><![CDATA[front_office_features]]></tab>

--- a/psgdpr.php
+++ b/psgdpr.php
@@ -51,6 +51,16 @@ class Psgdpr extends Module
     ];
 
     /**
+     * Hook a module registers on to declare itself to the GDPR consent settings.
+     */
+    private const CONSENT_REGISTRATION_HOOK = 'registerGDPRConsent';
+
+    /**
+     * Placeholder consent message a module gets until the merchant writes its own.
+     */
+    private const DEFAULT_CONSENT_MESSAGE = 'Enim quis fugiat consequat elit minim nisi eu occaecat occaecat deserunt aliquip nisi ex deserunt.';
+
+    /**
      * @var array
      */
     private $hooksUsedByModule = [
@@ -59,6 +69,7 @@ class Psgdpr extends Module
         'actionAdminControllerSetMedia',
         'additionalCustomerFormFields',
         'actionCustomerAccountAdd',
+        'actionModuleRegisterHookAfter',
     ];
 
     private $presetMessageAccountCreation = [
@@ -87,7 +98,7 @@ class Psgdpr extends Module
     {
         $this->name = 'psgdpr';
         $this->tab = 'administration';
-        $this->version = '2.0.3';
+        $this->version = '2.0.4';
         $this->author = 'PrestaShop';
         $this->need_instance = 0;
 
@@ -153,6 +164,7 @@ class Psgdpr extends Module
             $this->registerHook($this->hooksUsedByModule);
             $this->executeQuerySql(self::SQL_QUERY_TYPE_UNINSTALL);
             $this->executeQuerySql(self::SQL_QUERY_TYPE_INSTALL);
+            $this->getRegisteredModules();
         } catch (PrestaShopException $e) {
             /** @var LegacyLogger $legacyLogger */
             $legacyLogger = $this->get('prestashop.adapter.legacy.logger');
@@ -503,13 +515,38 @@ class Psgdpr extends Module
     }
 
     /**
+     * Register the consent as soon as a module declares itself on our hook, so that its
+     * consent checkbox works without waiting for the configuration page to be opened.
+     *
+     * @param array $params
+     *
+     * @return void
+     */
+    public function hookActionModuleRegisterHookAfter(array $params): void
+    {
+        if (!isset($params['hook_name'], $params['object'])
+            || strcasecmp($params['hook_name'], self::CONSENT_REGISTRATION_HOOK) !== 0
+        ) {
+            return;
+        }
+
+        $module = $params['object'];
+
+        if (!$module instanceof Module || (int) $module->id === (int) $this->id) {
+            return;
+        }
+
+        $this->addModuleConsent(['id_module' => (int) $module->id]);
+    }
+
+    /**
      * Get a module list of module trying to register to GDPR
      *
      * @return void
      */
     private function getRegisteredModules()
     {
-        $modulesRegistered = Hook::getHookModuleExecList('registerGDPRConsent');
+        $modulesRegistered = Hook::getHookModuleExecList(self::CONSENT_REGISTRATION_HOOK);
 
         if (empty($modulesRegistered)) {
             return;
@@ -531,34 +568,43 @@ class Psgdpr extends Module
      */
     private function addModuleConsent(array $module): void
     {
-        /** @var LangRepository $langRepository */
-        $langRepository = $this->get('prestashop.core.admin.lang.repository');
+        $moduleId = (int) $module['id_module'];
+        $db = Db::getInstance();
 
-        /** @var ConsentRepository $consentRepository */
-        $consentRepository = $this->get('PrestaShop\Module\Psgdpr\Repository\ConsentRepository');
-
-        $languages = $langRepository->findAll();
-        $shopId = $this->context->shop->id;
-        $consentExistForModule = $consentRepository->findModuleConsentExist($module['id_module']);
-
-        if (true === $consentExistForModule) {
+        // Deliberately written with the legacy layer. A consent row has to be created while a module
+        // is being installed, and while the shop installer runs, and in both cases the Doctrine
+        // repositories are out of reach: the container either does not exist yet, or it was compiled
+        // before this module was installed so LoadServicesFromModulesPass never registered its
+        // services. Module::get() returns null in the first case and throws ServiceNotFoundException
+        // in the second, and neither one is a PrestaShopException that install() could catch.
+        if ($db->getValue('SELECT id_gdpr_consent FROM `' . _DB_PREFIX_ . 'psgdpr_consent` WHERE id_module = ' . $moduleId)) {
             return;
         }
 
-        $psgdprConsent = new PsgdprConsent();
-        $psgdprConsent->setModuleId($module['id_module']);
-        $psgdprConsent->setActive(true);
+        $now = date('Y-m-d H:i:s');
 
-        /** @var Lang $language */
-        foreach ($languages as $language) {
-            $psgdprConsentLang = new PsgdprConsentLang();
-            $psgdprConsentLang->setLang($language);
-            $psgdprConsentLang->setMessage('Enim quis fugiat consequat elit minim nisi eu occaecat occaecat deserunt aliquip nisi ex deserunt.');
-            $psgdprConsentLang->setShopId($shopId);
-            $psgdprConsent->addConsentLang($psgdprConsentLang);
+        $inserted = $db->insert('psgdpr_consent', [
+            'id_module' => $moduleId,
+            'active' => 1,
+            'date_add' => pSQL($now),
+            'date_upd' => pSQL($now),
+        ]);
+
+        if (!$inserted) {
+            return;
         }
 
-        $consentRepository->createOrUpdateConsent($psgdprConsent);
+        $consentId = (int) $db->Insert_ID();
+        $shopId = (int) $this->context->shop->id;
+
+        foreach (Language::getLanguages(false) as $language) {
+            $db->insert('psgdpr_consent_lang', [
+                'id_gdpr_consent' => $consentId,
+                'id_lang' => (int) $language['id_lang'],
+                'id_shop' => $shopId,
+                'message' => pSQL(self::DEFAULT_CONSENT_MESSAGE),
+            ]);
+        }
     }
 
     /**

--- a/upgrade/upgrade-2.0.4.php
+++ b/upgrade/upgrade-2.0.4.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ */
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+/**
+ * @param Psgdpr $module
+ *
+ * @return bool
+ */
+function upgrade_module_2_0_4($module)
+{
+    // Consent rows used to be created only while rendering the configuration page.
+    // Listening to hook registrations creates them as soon as a module declares itself.
+    return $module->registerHook('actionModuleRegisterHookAfter');
+}


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | `ps_psgdpr_consent` holds one row per module that wants a consent checkbox, and `hookDisplayGDPRConsent()` renders nothing unless `GDPRConsent::getConsentActive($id_module)` finds one. The only code that creates those rows is `getRegisteredModules()`, whose only caller is `getContent()` - so the checkbox appears on the front office as a side effect of an employee opening the module's configuration page, and a shop where nobody opened it never shows one. Measured on 9.2 with the bundled version: `/contact-us` carries no consent markup with the table empty and the checkbox once the rows exist. The registration now runs on install and on upgrade as well.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes PrestaShop/PrestaShop#31789
| How to test?  | On a shop where `ps_psgdpr_consent` is empty and the module configuration page has never been opened, look at the contact form: before this change there is no consent checkbox, after installing or upgrading with this change there is. Opening the configuration page still registers any module added later.

## Root cause (measured, not read)

`ps_psgdpr_consent` holds one row per module that wants a consent checkbox. `hookDisplayGDPRConsent()`
returns `''` unless `GDPRConsent::getConsentActive($id_module)` finds one. The only code that creates those
rows is `getRegisteredModules()`, and it is called from **`getContent()` and nowhere else**  -  i.e. as a side
effect of an employee opening the module configuration page.

A/B on the 9.2 shop with the bundled psgdpr 1.4.3, nothing else changed between the two lines:

```
ps_psgdpr_consent EMPTY   ->  /contact-us  58,177 bytes, 0 gdpr markers
  ran getRegisteredModules() once, the one thing getContent() does
ps_psgdpr_consent 4 rows  ->  /contact-us  61,155 bytes, psgdpr_consent_checkbox present
```

`dev` (2.0.3) has the identical shape: `getRegisteredModules()` still has `getContent()` as its only caller.

## Why the thread could never agree

A state precondition, not a code path  -  it reproduces only on shops where nobody opened that page, which is
why AureRita and MatShir saw checkboxes on the same versions where RosaBenouamer, paulnoelcholot and
djoelleuch did not.

**Honest scope limit:** the reporter's steps say they ticked all five toggles, i.e. they *did* open the page,
so this may not be their path. I cleared the save path as the alternative explanation: the per-module
switches are paired radios (`dataConsent.tpl:169`/`172`, `value="1"`/`value="0"`), so both states POST and
`submitDataConsent()` cannot write `active=0` by omission. Said so in the upstream comment rather than
letting the tidier story absorb the discrepancy.

zodit/Miguel86/carlos-blazquez describe a *different* cause with the same symptom (psgdpr missing from the
`displayGDPRConsent` hook); `upgrade/upgrade-1.4.3.php` already repairs that one.

## The fix

1. **`actionModuleRegisterHookAfter` listener**  -  creates the row when a module declares itself on
   `registerGDPRConsent`, instead of on a page render.
2. **`getRegisteredModules()` at the end of `install()`**  -  sweeps modules registered before psgdpr.
3. **`addModuleConsent()` rewritten to write through the legacy `Db` layer** instead of the Doctrine
   repositories.

Both of (1) and (2) are needed: stock `id_module` ordering is productcomments=29, **psgdpr=31**,
contactform=56, ps_emailalerts=72  -  the first is reachable only by the sweep, the last two only by the
listener.

### Why (3)  -  this is the part that took two attempts

The first version kept Doctrine and added a null guard, reasoning that `Module::get()` returns `null` without
a container. That guard is **not sufficient**, and the install sweep built on it was actively harmful:

`Module::get()` catches only `ContainerNotFoundException`. When a container exists but was compiled *before*
this module was installed, `LoadServicesFromModulesPass` (which only iterates
`prestashop.installed_modules`) never registered the module's services, so `get()` **throws
`ServiceNotFoundException`**  -  before any guard can inspect the result, and not a `PrestaShopException` that
`install()` could catch.

Measured on the real path (uninstall psgdpr, drop the compiled container, install):

```
guard version:      container has ConsentRepository while psgdpr is NOT installed: false
                    install() THREW ServiceNotFoundException
                    consent rows created: 0        module left half-installed (installed=true)

legacy-Db version:  install() returned: true   errors: []
                    consent rows created: 4  (4 consents x 2 language rows)
                    FO /contact-us 64,693 bytes, checkbox present, 0 fatals
```

The rewrite also makes the listener work where the old one could only bail out:

```
container present:  contactform unregister -> register  =>  1 consent row
no container at all (legacy CLI):                        =>  1 consent row
```

## Verification notes

- Driven through a booted `AdminKernel` with `$context->container` set the way a BO controller supplies it,
  and through `$module->install()` in a **separate request** after clearing `var/cache/dev`, so the container
  is genuinely compiled without psgdpr  -  that is the condition that made the first attempt fail.
- **Test artefact worth not repeating:** `Hook::getHookModuleExecList()` builds its static cache for ALL
  hooks at the first `Hook::exec()` of the request. Registering psgdpr on a hook and then triggering that
  hook in the SAME request shows the listener never firing  -  the cache, not the code. That edge remains for
  "upgrade psgdpr and install a consumer in one request", where the config-page sweep is the backstop.
- Shop restored to baseline afterwards: psgdpr 1.4.3, 5 hook rows, 0 consent rows, `/contact-us` back to
  58,177 bytes, core working tree clean.

## Gates

- `php -l` on both changed PHP files  -  clean. Added syntax (`private const`, `: void`) is 7.1+, so the 7.2
  CI matrix leg is safe.
- `php-cs-fixer` with the module's own `.php-cs-fixer.dist.php`  -  clean.
- PHPStan level 5 with `tests/phpstan/phpstan-9.2.x.neon`  -  `psgdpr.php` 0 errors, unchanged from baseline
  (250 pre-existing errors live in `src/` and `controllers/`, untouched). The local run has no core classes
  wired, so CI stays authoritative.

## Coordination

- **PR #235** (PululuK/Evolutive, open) makes `getRegisteredModules()` run *less* often on the config page.
  Complementary  -  this change removes the reason the page-render sweep has to be the creation path at all  - 
  but it **also adds `upgrade/upgrade-2.0.4.php`**, a direct filename collision to resolve at publish
  (renumber whichever lands second).
- **PR #230** (lmeyer1, open) puts `id_shop` in the `psgdpr_consent_lang` primary key. The rewritten insert
  writes `id_shop` exactly as the Doctrine path did (`$this->context->shop->id`, one lang row per language),
  so it adds no new scoping and does not make multistore worse. The pre-existing asymmetry  - 
  `findModuleConsentExist()`/`getConsentActive()` do not filter shop while `checkIfExist()` does  -  is #230's
  territory.
- **Delivery gap:** core 9.2 pins `"prestashop/psgdpr": "^1.4"` -> **v1.4.3 (Dec 2022)** while `dev` is 2.0.3,
  so a `dev` fix reaches no 9.2 shop until core bumps that constraint, and no 1.4.x maintenance line exists
  (`1.4.3` is a release snapshot). Recorded as DECISIONS A7 rather than acted on unilaterally.

## Review risk to expect

The module is migrating *to* Doctrine, and (3) moves one write back to the legacy layer. The justification is
mechanical and measured  -  no container exists at the two call sites that matter  -  but a maintainer may prefer
a different shape (e.g. a container-free repository, or deferring creation to the first BO request). Worth
leading the PR description with the `install() THREW ServiceNotFoundException` measurement.
